### PR TITLE
add: Navbar 우측에 검색 (Search) 컴포넌트 UI 작업 및 추가

### DIFF
--- a/app/components/navbar/Search.tsx
+++ b/app/components/navbar/Search.tsx
@@ -1,7 +1,23 @@
 'use client';
 
 import React from 'react';
+import { BiSearch } from 'react-icons/bi';
 
 export default function Search() {
-  return <div>Search</div>;
+  return (
+    <div className="w-full cursor-pointer rounded-full border-[1px] py-2 shadow-sm transition hover:shadow-md md:w-auto">
+      <div className="flex flex-row items-center justify-between">
+        <div className="px-6 text-sm font-semibold">Anywhere</div>
+        <div className="hidden flex-1 border-x-[1px] px-6 text-center text-sm font-semibold sm:block">
+          Any Week
+        </div>
+        <div className="flex flex-row items-center gap-3 pl-6 pr-2 text-sm text-gray-600">
+          <div className="hidden sm:block">Add Guests</div>
+          <div className="rounded-full bg-rose-500 p-2 text-white">
+            <BiSearch size={18} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "postcss": "8.4.24",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-icons": "^4.9.0",
     "tailwindcss": "3.3.2",
     "typescript": "5.1.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2092,6 +2092,11 @@ react-dom@18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-icons@^4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.9.0.tgz#ba44f436a053393adb1bdcafbc5c158b7b70d2a3"
+  integrity sha512-ijUnFr//ycebOqujtqtV9PFS7JjhWg0QU6ykURVHuL4cbofvRCf3f6GMn9+fBktEFQOIVZnuAYLZdiyadRQRFg==
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
- React-icons 설치 및 Search 컴포넌트 생성 및 적용
- NextJS 는 컴포넌트가 기본 서버 컴포넌트이므로 React 의 hook 등을 사용하고자 할 때 혹은 서버 사이드 렌더링을 요하지 않을 경우, 'use client' 를 상단에 명시

<img width="781" alt="스크린샷 2023-06-11 오후 8 28 16" src="https://github.com/seolleung2/airbnb-nextjs/assets/69143207/edfd41b3-71bf-4a2d-b858-a9e0f818d46f">
