### PR TITLE
add: Register 모달 내 body 에 Heading, Input 컴포넌트 생성 및 적용. react-hot-toas…

### DIFF
--- a/app/components/Heading.tsx
+++ b/app/components/Heading.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import React from 'react';
+
+interface HeadingProps {
+  title: string;
+  subtitle?: string;
+  center?: boolean;
+}
+
+export default function Heading({ title, subtitle, center }: HeadingProps) {
+  return (
+    <div className={center ? 'text-center' : 'text-start'}>
+      <div className="text-2xl font-bold">{title}</div>
+      <div className="mt-2 font-light text-neutral-500">{subtitle}</div>
+    </div>
+  );
+}

--- a/app/components/inputs/index.tsx
+++ b/app/components/inputs/index.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import React from 'react';
+import { FieldErrors, FieldValues, UseFormRegister } from 'react-hook-form';
+import classnames from 'classnames';
+
+import { BiDollar } from 'react-icons/bi';
+
+interface InputProps {
+  id: string;
+  label: string;
+  type?: string;
+  disabled?: boolean;
+  formatPrice?: boolean;
+  required?: boolean;
+  register: UseFormRegister<FieldValues>;
+  errors: FieldErrors;
+}
+
+export default function Input({
+  id,
+  label,
+  type = 'text',
+  disabled,
+  formatPrice,
+  required,
+  register,
+  errors,
+}: InputProps) {
+  return (
+    <div className="relative w-full">
+      {formatPrice && <BiDollar size={24} className={classnames(``)} />}
+      <input
+        id={id}
+        disabled={disabled}
+        {...register(id, { required })}
+        placeholder=" "
+        type={type}
+        className={classnames(
+          'peer w-full rounded-md border-2 bg-white p-4 pt-6 font-light outline-none transition disabled:cursor-not-allowed disabled:opacity-70',
+          formatPrice ? 'pl-9' : 'pl-4',
+          errors[id]
+            ? 'border-rose-500 focus:border-rose-500'
+            : 'border-neutral-300 focus:border-black'
+        )}
+      />
+      <label
+        className={classnames(
+          'text-md absolute top-5 z-10 origin-[0] -translate-y-3 transform duration-150 peer-placeholder-shown:translate-y-0 peer-placeholder-shown:scale-100 peer-focus:-translate-y-4 peer-focus:scale-75',
+          formatPrice ? 'left-9' : 'left-4',
+          errors[id] ? 'text-rose-500' : 'text-zinc-400'
+        )}
+      >
+        {label}
+      </label>
+    </div>
+  );
+}

--- a/app/components/modals/RegisterModal.tsx
+++ b/app/components/modals/RegisterModal.tsx
@@ -5,7 +5,10 @@ import axios from 'axios';
 import { AiFillGithub } from 'react-icons/ai';
 import { FcGoogle } from 'react-icons/fc';
 import { FieldValues, SubmitHandler, useForm } from 'react-hook-form';
+import { toast } from 'react-hot-toast';
 
+import Heading from '@components/Heading';
+import Input from '@components/inputs';
 import useRegisterModal from '@hooks/useRegisterModal';
 import Modal from './Modal';
 
@@ -35,6 +38,7 @@ export default function RegisterModal() {
       })
       .catch((error) => {
         console.log(error);
+        toast.error('Something went wrong..');
       })
       .finally(() => {
         setIsLoading(false);
@@ -42,7 +46,34 @@ export default function RegisterModal() {
   };
 
   const bodyContent = (
-    <div className="flex flex-col gap-4">Hello Modal Body!</div>
+    <div className="flex flex-col gap-4">
+      <Heading title="Welcome to Airbnb" subtitle="Create an Account!" />
+      <Input
+        id="email"
+        label="Email"
+        disabled={isLoading}
+        register={register}
+        errors={errors}
+        required
+      />
+      <Input
+        id="name"
+        label="Name"
+        disabled={isLoading}
+        register={register}
+        errors={errors}
+        required
+      />
+      <Input
+        id="password"
+        type="password"
+        label="Password"
+        disabled={isLoading}
+        register={register}
+        errors={errors}
+        required
+      />
+    </div>
   );
 
   return (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Nunito } from 'next/font/google';
 import Navbar from '@components/navbar';
 import ClientOnly from '@components/ClientOnly';
 import RegisterModal from '@components/modals/RegisterModal';
+import ToasterProvider from '@providers/ToasterProvider';
 
 const font = Nunito({ subsets: ['latin'] });
 
@@ -20,6 +21,7 @@ export default function RootLayout({
     <html lang="en">
       <body className={font.className}>
         <ClientOnly>
+          <ToasterProvider />
           <RegisterModal />
           <Navbar />
         </ClientOnly>

--- a/app/providers/ToasterProvider.tsx
+++ b/app/providers/ToasterProvider.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import React from 'react';
+import { Toaster } from 'react-hot-toast';
+
+export default function ToasterProvider() {
+  return <Toaster />;
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.45.1",
+    "react-hot-toast": "^2.4.1",
     "react-icons": "^4.9.0",
     "tailwindcss": "3.3.2",
     "typescript": "5.1.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,9 @@
       "@components/*": ["components/*"],
       "@components": ["components"],
       "@hooks/*": ["hooks/*"],
-      "@hooks": ["hooks"]
+      "@hooks": ["hooks"],
+      "@providers/*": ["providers/*"],
+      "@providers": ["providers"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1313,6 +1313,11 @@ globby@^13.1.3:
     merge2 "^1.4.1"
     slash "^4.0.0"
 
+goober@^2.1.10:
+  version "2.1.13"
+  resolved "https://registry.yarnpkg.com/goober/-/goober-2.1.13.tgz#e3c06d5578486212a76c9eba860cbc3232ff6d7c"
+  integrity sha512-jFj3BQeleOoy7t93E9rZ2de+ScC4lQICLwiAQmKMg9F6roKGaLSHoCDYKkWlSafg138jejvq/mTdvmnwDQgqoQ==
+
 gopd@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
@@ -2158,6 +2163,13 @@ react-hook-form@^7.45.1:
   version "7.45.1"
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.45.1.tgz#e352c7f4dbc7540f0756abbb4dcfd1122fecc9bb"
   integrity sha512-6dWoFJwycbuFfw/iKMcl+RdAOAOHDiF11KWYhNDRN/OkUt+Di5qsZHwA0OwsVnu9y135gkHpTw9DJA+WzCeR9w==
+
+react-hot-toast@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/react-hot-toast/-/react-hot-toast-2.4.1.tgz#df04295eda8a7b12c4f968e54a61c8d36f4c0994"
+  integrity sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==
+  dependencies:
+    goober "^2.1.10"
 
 react-icons@^4.9.0:
   version "4.9.0"


### PR DESCRIPTION
…t 적용

- Heading, Input 컴포넌트 생성 및 RegisterModal 내 body 에 적용
- react-hot-toast 설치 및 ToasterProvider 컴포넌트 생성 후 메인 layout 에 적용.
- api 호출 후 try-catch 문의 catch 에서 toast.error 를 통해 에러 alert 를 상단에 보여지도록 적용.
<img width="1240" alt="스크린샷 2023-07-17 오후 11 53 10" src="https://github.com/seolleung2/airbnb-nextjs/assets/69143207/1130ddc0-18c7-444e-84dc-5f0505efbc37">
