### PR TITLE
add: .env 에 GOOGLE_CLIENT_ID, SECRET 추가 + 구글 로그인 연동

### DIFF
--- a/app/components/modals/LoginModal.tsx
+++ b/app/components/modals/LoginModal.tsx
@@ -86,7 +86,7 @@ export default function LoginModal() {
         outline
         label="Continue with Google"
         icon={FcGoogle}
-        onClick={() => {}}
+        onClick={() => signIn('google')}
       />
       <Button
         outline

--- a/app/components/modals/RegisterModal.tsx
+++ b/app/components/modals/RegisterModal.tsx
@@ -85,7 +85,7 @@ export default function RegisterModal() {
         outline
         label="Continue with Google"
         icon={FcGoogle}
-        onClick={() => {}}
+        onClick={() => signIn('google')}
       />
       <Button
         outline

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ['avatars.githubusercontent.com'],
+    domains: ['avatars.githubusercontent.com', 'lh3.googleusercontent.com'],
   },
 };
 


### PR DESCRIPTION
- google cloud 에서 새 프로젝트 생성
- API 및 서비스 > OAuth 동의 화면
- API 및 서비스 > 사용자 인증 정보 > 리디렉션 URL 설정 (http://localhost:3000/api/auth/callback/google)
- 클라이언트ID, SECRET 복사후 .env 에 저장
- 모달 (Register, Login) 에서 onClick 시 구글 로그인 연동
<img width="1122" alt="스크린샷 2023-07-31 오후 10 22 17" src="https://github.com/seolleung2/airbnb-nextjs/assets/69143207/ffb410d0-1e95-4c7e-af3f-fe4f50db9a4b">
